### PR TITLE
Agregada funcionalidad para que un cliente confirme la entrega de su pedido

### DIFF
--- a/comandaPSS/src/app/models/interfaces/pedido.model.ts
+++ b/comandaPSS/src/app/models/interfaces/pedido.model.ts
@@ -12,5 +12,5 @@ export interface Pedido {
     preparaciones: Array<Preparacion>;
 }
 
-export type PedidoEstado = "pendiente" | "preparando" | "terminado" | "entregado" | "aPagar" | "pagado";
+export type PedidoEstado = "pendiente" | "preparando" | "terminado" | "confirmarEntrega" | "entregado" | "aPagar" | "pagado";
 

--- a/comandaPSS/src/app/pages/clientes/mesa/mesa.page.html
+++ b/comandaPSS/src/app/pages/clientes/mesa/mesa.page.html
@@ -32,6 +32,15 @@
     Hacer pedido
   </ion-button>
   <ion-button
+    *ngIf="pedido?.estado === 'confirmarEntrega'"
+    (click)="confirmarEntrega()"
+    expand="block"
+    fill="clear"
+    shape="round"
+  >
+    Confirmar entrega
+  </ion-button>
+  <ion-button
     *ngIf="pedido?.estado === 'entregado'"
     (click)="pedirCuenta()"
     expand="block"

--- a/comandaPSS/src/app/pages/clientes/mesa/mesa.page.ts
+++ b/comandaPSS/src/app/pages/clientes/mesa/mesa.page.ts
@@ -133,6 +133,11 @@ export class MesaPage implements OnInit {
     }
   }
 
+  confirmarEntrega() {
+    this.pedido.estado = "entregado";
+    this.pedidoService.updatePedido(this.pedido);
+  }
+
   async pedirCuenta() {
     const propina = await this.qrService.scanPropina();
     if (propina > -1) {

--- a/comandaPSS/src/app/pages/mozo/components/pedidos/pedidos.component.ts
+++ b/comandaPSS/src/app/pages/mozo/components/pedidos/pedidos.component.ts
@@ -64,7 +64,7 @@ export class PedidosComponent implements OnInit {
   }
 
   public entregarPedido(pedido: Pedido) {
-    pedido.estado = "entregado";
+    pedido.estado = "confirmarEntrega";
     this.pedidoService.updatePedido(pedido);
   }
 


### PR DESCRIPTION
- Nuevo estado `confirmarEntrega` en Pedido
- Nuevo botón en pantalla de cliente, disponible cuando el Pedido se encuentra en estado `confirmarEntrega`. Al presionarlo el Pedido pasa a estado `entregado`